### PR TITLE
Fix pydantic field documentation for List/Set/Tuple

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -679,7 +679,7 @@ class Loader:
             path=path,
             file_path=node.file_path,
             docstring=prop.field_info.description,
-            attr_type=prop.type_,
+            attr_type=prop.outer_type_,
             properties=properties,
         )
 

--- a/tests/fixtures/pydantic.py
+++ b/tests/fixtures/pydantic.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 from pydantic import BaseModel, Field
 
 
@@ -6,3 +8,4 @@ class Person(BaseModel):
 
     name: str = Field("PersonA", description="The person's name")
     age: int = Field(18, description="The person's age which must be at minimum 18")
+    labels: Set[str] = Field(set(), description="Set of labels the person can be referred by")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from pathlib import Path
+from typing import Set
 
 import pytest
 from marshmallow import fields
@@ -223,6 +224,10 @@ def test_loading_pydantic_model():
     assert age_attr.type == int
     assert age_attr.docstring == "The person's age which must be at minimum 18"
     assert "pydantic-field" in age_attr.properties
+    labels_attr = next(attr for attr in obj.attributes if attr.name == "labels")
+    assert labels_attr.type == Set[str]
+    assert labels_attr.docstring == "Set of labels the person can be referred by"
+    assert "pydantic-field" in labels_attr.properties
 
 
 def test_loading_marshmallow_model():


### PR DESCRIPTION
Fixes #94 

Note that I have tested this for these types
List, Set, Tuple, Union

Update on why Optional isn't working: [This explains it](https://github.com/samuelcolvin/pydantic/blob/b7a8ef25c667b5dd4c4cd0b109c6625d1a57139a/pydantic/fields.py#L517-L521)
