### PR TITLE
Bugfix duplicate dataclass attributes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ make setup
     ```
 
     Now you can try running `make setup` again,
-    or simply `poetry install`.
+    or simply `poetry install -E numpy-style`.
 
 You now have the dependencies installed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ pytest-sugar = "^0.9.4"
 pytest-xdist = "^2.2.0"
 toml = "^0.10.2"
 wemake-python-styleguide = "^0.14.1"
+marshmallow = "^3.11.1"
 
 [tool.poetry.scripts]
 pytkdocs = "pytkdocs.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6.1"
 astunparse = {version = "^1.6.3", python = "<3.9"}
 cached-property = {version = "^1.5.2", python = "<3.8"}
 dataclasses = {version = ">=0.7,<0.9", python = "3.6"}
@@ -57,6 +57,7 @@ pytest-sugar = "^0.9.4"
 pytest-xdist = "^2.2.0"
 toml = "^0.10.2"
 wemake-python-styleguide = "^0.14.1"
+pydantic = "^1.8.1"
 marshmallow = "^3.11.1"
 
 [tool.poetry.scripts]

--- a/src/pytkdocs/objects.py
+++ b/src/pytkdocs/objects.py
@@ -256,7 +256,7 @@ class Object(metaclass=ABCMeta):
             self.methods.append(obj)  # type: ignore
         elif isinstance(obj, Attribute):
             # Dataclass attributes with default values will already be present in `self.attributes` as they are
-            # resolved differently by the python interpreter. Aas they have a concrete value, they are already present
+            # resolved differently by the python interpreter. As they have a concrete value, they are already present
             # in the "original" class. They should be overridden with the new "dataclass" attribute coming in here
             # (having the "dataclass_field" property set)
             new_attribute_name = obj.name

--- a/src/pytkdocs/objects.py
+++ b/src/pytkdocs/objects.py
@@ -255,6 +255,14 @@ class Object(metaclass=ABCMeta):
         elif isinstance(obj, Method):
             self.methods.append(obj)  # type: ignore
         elif isinstance(obj, Attribute):
+            # Dataclass attributes with default values will already be present in `self.attributes` as they are
+            # resolved differently by the python interpreter. Aas they have a concrete value, they are already present
+            # in the "original" class. They should be overridden with the new "dataclass" attribute coming in here
+            # (having the "dataclass_field" property set)
+            new_attribute_name = obj.name
+            for attribute in self.attributes:
+                if attribute.name == new_attribute_name:
+                    self.attributes.remove(attribute)
             self.attributes.append(obj)  # type: ignore
         obj.parent = self
 

--- a/tests/fixtures/dataclass.py
+++ b/tests/fixtures/dataclass.py
@@ -6,7 +6,7 @@ class Person:
     """Simple dataclass for a person's information"""
 
     name: str
-    age: int
+    age: int = 2
     """Field description."""
 
 


### PR DESCRIPTION
This should fix the issue of dataclasses having duplicate attributes when these have defaults. This occurs because attributes with defaults are interpreted differently by Python (as they have a default, they already "exist" in the "regular" class). 

The solution implemented here first checks if the argument is already present in `self.arguments` (comparison by name). If it is, it replaces the old argument (as the new one has the `dataclass_field` property set).