### PR TITLE
[FEATURE] Allow method_descriptors to be serialized as methods

### DIFF
--- a/tests/fixtures/method_descriptor.py
+++ b/tests/fixtures/method_descriptor.py
@@ -1,0 +1,3 @@
+"""See https://docs.python.org/3/library/inspect.html#inspect.ismethoddescriptor for details"""
+
+descriptor = int.__add__

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -511,3 +511,14 @@ def test_loading_cached_properties():
     assert len(obj.children) == 1
     assert obj.children[0].name == obj.children[0].docstring == "aaa"
     assert "cached" in obj.children[0].properties
+
+
+def test_method_descriptor():
+    """Load a method descriptor."""
+    loader = Loader(new_path_syntax=True)
+    obj = loader.get_object_documentation("tests.fixtures.method_descriptor:descriptor")
+    assert obj.name == "descriptor"
+    assert obj.signature
+    assert len(obj.signature.parameters) == 2
+    assert obj.docstring
+    assert obj.category == "method"


### PR DESCRIPTION
Hi,

I'm trying to add support for python methods created using [pyo3](https://pyo3.rs/). These methods are "built-in" methods, however they can still expose the `__doc__` attribute and a function signature via `__text_signature__`.

The current implementation detects `method_descriptors` (which is what most native functions end up as), and serializes them as regular methods (since from a caller point of view, they act the same). If the user doesn't provide the `__text_signature__` attribute, `inspect.signature` will error out, so I made it optional, as I still think it would be useful to have the docstring in the resulting documentation if it exists. 

Please let me know if this is the right direction for this approach. There are other modifications coming to `mkdocstrings` too, as it currently doesn't populate functions/methods with `__text_signature__` or with no signature very well.

Thanks,