### PR TITLE
feat: Support "Keyword Args" sections for G-style

### DIFF
--- a/src/pytkdocs/parsers/docstrings/base.py
+++ b/src/pytkdocs/parsers/docstrings/base.py
@@ -107,6 +107,7 @@ class Section:
         RETURN = "return"
         EXAMPLES = "examples"
         ATTRIBUTES = "attributes"
+        KEYWORD_ARGS = "keyword_args"
 
     def __init__(self, section_type: str, value: Any) -> None:
         """


### PR DESCRIPTION
Add support for "Keyword Args" and "Keyword Arguments" sections for
Google-style docstrings.

Closes #88.