### PR TITLE
fix: Support future annotations

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -5,6 +5,8 @@ It uses [`inspect`](https://docs.python.org/3/library/inspect.html) for introspe
 iterating over their members, etc.
 """
 
+from __future__ import annotations
+
 import importlib
 import inspect
 import pkgutil

--- a/tests/fixtures/final.py
+++ b/tests/fixtures/final.py
@@ -1,0 +1,10 @@
+# from __future__ import annotations
+
+from typing import Final, get_type_hints
+
+name: Final[str] = "final"
+
+class Class:
+    value: Final = 3000
+
+# get_type_hints(Class)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -536,3 +536,8 @@ def test_load_decorated_function():
         assert child.category == "function"
         assert child.parent is child.root
         assert child.parent.name == "decorated_function"
+
+def test_load_final_annotations():
+    """Load things annotated as final."""
+    loader = Loader(new_path_syntax=True)
+    obj = loader.get_object_documentation("tests.fixtures.final")


### PR DESCRIPTION
Waiting for https://github.com/python/cpython/pull/28279, though we could already ship it.
Probably as a bugfix release, just in case it breaks things for some users, so they can discard the bugfix version in their accepted range.