### PR TITLE
fix: Skip 'could not read code' errors for special methods

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -410,7 +410,6 @@ class Loader:
             try:
                 code = Path(node.file_path).read_text()
             except (OSError, UnicodeDecodeError):
-                self.errors.append(f"Couldn't read source for '{path}': {error}")
                 source = None
             else:
                 source = Source(code, 1) if code else None
@@ -628,13 +627,11 @@ class Loader:
         try:
             signature = inspect.signature(function)
         except TypeError as error:
-            self.errors.append(f"Couldn't get signature for '{path}': {error}")
             signature = None
 
         try:
             source = Source(*inspect.getsourcelines(function))
         except OSError as error:
-            self.errors.append(f"Couldn't read source for '{path}': {error}")
             source = None
 
         properties: List[str] = []
@@ -677,7 +674,6 @@ class Loader:
         try:
             signature = inspect.signature(sig_source_func)
         except (TypeError, ValueError) as error:
-            self.errors.append(f"Couldn't get signature for '{path}': {error}")
             attr_type = None
         else:
             attr_type = signature.return_annotation
@@ -685,7 +681,6 @@ class Loader:
         try:
             source = Source(*inspect.getsourcelines(sig_source_func))
         except (OSError, TypeError) as error:
-            self.errors.append(f"Couldn't get source for '{path}': {error}")
             source = None
 
         return Attribute(
@@ -879,8 +874,6 @@ class Loader:
         try:
             source = Source(*inspect.getsourcelines(method))
         except OSError as error:
-            if not RE_SPECIAL.match(node.name):
-                self.errors.append(f"Couldn't read source for '{path}': {error}")
             source = None
         except TypeError:
             source = None
@@ -899,7 +892,6 @@ class Loader:
             # raise a ValueError().
             signature = inspect.signature(method)
         except ValueError as error:
-            self.errors.append(f"Couldn't read signature for '{path}': {error}")
             signature = None
 
         return Method(

--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -879,7 +879,8 @@ class Loader:
         try:
             source = Source(*inspect.getsourcelines(method))
         except OSError as error:
-            self.errors.append(f"Couldn't read source for '{path}': {error}")
+            if not RE_SPECIAL.match(node.name):
+                self.errors.append(f"Couldn't read source for '{path}': {error}")
             source = None
         except TypeError:
             source = None

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -116,16 +116,7 @@ def test_inheriting_typing_NamedTuple():
     """
     loader = Loader()
     loader.get_object_documentation("tests.fixtures.inheriting_typing_NamedTuple")
-
-    if sys.version_info > (3, 7, 99):
-        assert len(loader.errors) == 1
-    else:
-        # there are 4 class-attributes, 2 errors (source, signature) per attribute
-        assert len(loader.errors) >= 8
-        for error in loader.errors[-8:]:
-            assert "itemgetter" in error
-        for error in loader.errors[:-8]:
-            assert "could not get source code" in error
+    assert len(loader.errors) == 0
 
 
 def test_nested_class():


### PR DESCRIPTION
This is usually not actionable: the user cannot fix the warning.

Issue #111: https://github.com/mkdocstrings/pytkdocs/issues/111