### PR TITLE
refactor: Remove warning about new path style option

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The configuration options available are:
 
 <sup>1</sup>: reStructured Text parsing is in active development and is not feature complete yet.
 <sup>2</sup>: The following sections are currently not supported : `Notes`, `See Also`, `Warns` and `References`.
+
 ### Details on `new_path_syntax`
 
 Example:
@@ -225,19 +226,3 @@ Example:
   old importing behavior.
 - If there isn't a colon, and `new_path_syntax` is true, `pytkdocs` uses the new
   importing behavior and therefore considers that the path points to a module.
-
-!!! warning "The `new_path_syntax` option is temporary."
-    It exists only to ease the transition to the new path syntax.
-    
-    Here is an idea of its life time:
-    
-    - **version 0.9:** the default value for `new_path_syntax` is false.
-      A pending deprecation warning is emmitted to tell users to switch to the new path syntax.
-    - **once version 0.10 is published:** [`mkdocstrings`](https://github.com/pawamoy/mkdocstrings)
-      will log an MkDocs warning, making the builds fail
-      when `new_path_syntax` is false and strict mode is enabled.
-    - **version 0.11:** the default value for `new_path_syntax` becomes true,
-      and the warning becomes a deprecation warning.
-    - **version 0.13:** the `new_path_syntax` option is removed.
-    
-    Please update your paths to use the new colon syntax as soon as possible.

--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -9,7 +9,6 @@ import importlib
 import inspect
 import pkgutil
 import re
-import warnings
 from functools import lru_cache
 from itertools import chain
 from operator import attrgetter
@@ -335,16 +334,6 @@ class Loader:
         self.errors: List[str] = []
         self.select_inherited_members = inherited_members
         self.new_path_syntax = new_path_syntax
-
-        if not new_path_syntax:
-            warnings.warn(
-                "With pytkdocs v0.9, the 'new_path_syntax` option was introduced. "
-                "The default value is False, but will become True in v0.11, "
-                "and the option will be removed in v0.13. "
-                "Please update your paths to use a colon to delimit modules from other objects. "
-                "Read more at https://pawamoy.github.io/pytkdocs/#details-on-new_path_syntax",
-                PendingDeprecationWarning,
-            )
 
     def get_object_documentation(self, dotted_path: str, members: Optional[Union[Set[str], bool]] = None) -> Object:
         """


### PR DESCRIPTION
pytkdocs will eventually be replaced by griffe.
It means maintenance plans for pytkdocs are dropped
as it will not evolve a lot until griffe is used.