### PR TITLE
pass context to parse_docstring

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -475,7 +475,7 @@ class Loader:
                 context["signature"] = inspect.signature(class_.__init__)
             except (TypeError, ValueError):
                 pass
-        root_object.parse_docstring(self.docstring_parser, attributes=attributes_data)
+        root_object.parse_docstring(self.docstring_parser, **context)
 
         if select_members is False:
             return root_object


### PR DESCRIPTION
The full context was not being passed to `parse_docstring`. This was not allowing `Class` signatures to be passed down for extra context and instead would only rely on the class docstring itself.