### PR TITLE
fix: add source to class object

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -460,8 +460,21 @@ class Loader:
         class_ = node.obj
         docstring = inspect.cleandoc(class_.__doc__ or "")
         bases = [self._class_path(b) for b in class_.__bases__]
+
+        source: Optional[Source]
+
+        try:
+            source = Source(*inspect.getsourcelines(node.obj))
+        except (OSError, TypeError) as error:
+            source = None
+
         root_object = Class(
-            name=node.name, path=node.dotted_path, file_path=node.file_path, docstring=docstring, bases=bases
+            name=node.name,
+            path=node.dotted_path,
+            file_path=node.file_path,
+            docstring=docstring,
+            bases=bases,
+            source=source,
         )
 
         # Even if we don't select members, we want to correctly parse the docstring


### PR DESCRIPTION
Adds `Source` when instantiating `Class` in `get_class_documentation`

This [feature](https://github.com/mkdocstrings/mkdocstrings/pull/274) in `mkdocstrings` allowed for sorting of members on render via `members_order: source`. 

It relies on `source.line_start` existing on the objects that are being sorted. 

For  example a file of Classes will now render correctly with respect to the `members_order: source`