### PR TITLE
Add support for help_text field parameter as docstring for django model fields.

### DIFF
--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -747,7 +747,7 @@ class Loader:
         if prop.help_text:
             docstring = f"{prop.verbose_name}: {prop.help_text}"
         else:
-            docstring = "{}".format(prop.verbose_name)
+            docstring = str(prop.verbose_name)
 
         return Attribute(
             name=node.name,

--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -745,7 +745,7 @@ class Loader:
         # both should be converted to str type in case lazy translation
         # is being used, which is common scenario in django
         if prop.help_text:
-            docstring = "`{}`: {}".format(prop.verbose_name, prop.help_text)
+            docstring = f"{prop.verbose_name}: {prop.help_text}"
         else:
             docstring = "{}".format(prop.verbose_name)
 

--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -745,7 +745,7 @@ class Loader:
         # both should be converted to str type in case lazy translation
         # is being used, which is common scenario in django
         if prop.help_text:
-            docstring = "{} - {}".format(prop.verbose_name, prop.help_text)
+            docstring = "`{}`: {}".format(prop.verbose_name, prop.help_text)
         else:
             docstring = "{}".format(prop.verbose_name)
 

--- a/src/pytkdocs/loader.py
+++ b/src/pytkdocs/loader.py
@@ -741,11 +741,19 @@ class Loader:
         if prop.blank:
             properties.append("blank")
 
+        # set correct docstring based on verbose_name and help_text
+        # both should be converted to str type in case lazy translation
+        # is being used, which is common scenario in django
+        if prop.help_text:
+            docstring = "{} - {}".format(prop.verbose_name, prop.help_text)
+        else:
+            docstring = "{}".format(prop.verbose_name)
+
         return Attribute(
             name=node.name,
             path=path,
             file_path=node.file_path,
-            docstring=prop.verbose_name,
+            docstring=docstring,
             attr_type=prop.__class__,
             properties=properties,
         )


### PR DESCRIPTION
Here are added features:

- support for `help_text` parameter of django model field
- casting docstring to string type, which solves the problem of serializing `Proxy` objects in case of lazy translation

This is the final result with and without `help_text`:

![image](https://user-images.githubusercontent.com/80712622/146465275-21af5dfb-bbaf-49c1-8a79-efc10d781a72.png)

this closes #127 