### PR TITLE
feat: Add `trim_doctest_flag` to google and numpy parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The configuration options available are:
     - `!^_`: filter out every object whose name starts with `_` (private/protected)
     - `^__`: but still select those who start with two `_` (class-private)
     - `!^__.*__$`: except those who also end with two `_` (specials)
-  
+
 - `members`: this option allows to explicitly select the members of the top-object.
   If `True`, select every members that passes filters. If `False`, select nothing.
   If it's a list of names, select only those members, and apply filters on their children only.
@@ -196,13 +196,16 @@ The configuration options available are:
 - `docstring_style`: the docstring style to use when parsing the docstring. `google`, `restructured-text`<sup>1</sup> and `numpy`<sup>2</sup>.
 
 - `docstring_options`: options to pass to the docstring parser.
-    - `google` accepts a `replace_admonitions` boolean option (default: true). When enabled, this option will
+    - `replace_admonitions` boolean option (default: true). When enabled, this option will
       replace titles of an indented block by their Markdown admonition equivalent:
       `AdmonitionType: Title` will become `!!! admonitiontype "Title"`.
-    - `restructured-text` does not accept any options.
-    - `numpy` does not accept any options.
+    - `trim_doctest_flags` boolean option (default: true). When enabled, all doctest
+      flags (of the form `# doctest: +FLAG` and `<BLANKLINE>`) located within python
+      example blocks will be removed from the parsed output.
 
-<sup>1</sup>: reStructured Text parsing is in active development and is not feature complete yet.
+    The `google` docstring style accepts both options. The `numpy` style only accepts `trim_doctest_flags`. The `restructured-text` style does not accept any options.
+
+<sup>1</sup>: reStructured Text parsing is in active development and is not feature complete yet.</br>
 <sup>2</sup>: The following sections are currently not supported : `Notes`, `See Also`, `Warns` and `References`.
 
 ### Details on `new_path_syntax`

--- a/tests/test_parsers/test_docstrings/test_numpy.py
+++ b/tests/test_parsers/test_docstrings/test_numpy.py
@@ -11,11 +11,18 @@ class DummyObject:
     path = "o"
 
 
-def parse(docstring, signature=None, return_type=inspect.Signature.empty):
+def parse(
+    docstring,
+    signature=None,
+    return_type=inspect.Signature.empty,
+    trim_doctest=False,
+):
     """Helper to parse a doctring."""
-    return Numpy().parse(
+    parser = Numpy(trim_doctest_flags=trim_doctest)
+
+    return parser.parse(
         dedent(docstring).strip(),
-        {"obj": DummyObject(), "signature": signature, "type": return_type},
+        context={"obj": DummyObject(), "signature": signature, "type": return_type},
     )
 
 
@@ -48,13 +55,13 @@ def test_sections_without_signature():
 
         Parameters
         ----------
-        void : 
+        void :
             SEGFAULT.
-        niet : 
+        niet :
             SEGFAULT.
-        nada : 
+        nada :
             SEGFAULT.
-        rien : 
+        rien :
             SEGFAULT.
 
         Raises
@@ -63,7 +70,7 @@ def test_sections_without_signature():
             when nothing works as expected.
 
         Returns
-        ------- 
+        -------
         bool
             Itself.
         """
@@ -135,8 +142,48 @@ def test_function_with_annotations():
     assert not errors
 
 
+def test_function_with_examples_trim_doctest():
+    """Parse example docstring with trim_doctest_flags option."""
+
+    def f(x: int) -> int:
+        """Test function.
+
+        Example
+        -------
+        We want to skip the following test.
+        >>> 1 + 1 == 3  # doctest: +SKIP
+        True
+
+        And then a few more examples here:
+        >>> print("a\\n\\nb")
+        a
+        <BLANKLINE>
+        b
+        >>> 1 + 1 == 2  # doctest: +SKIP
+        >>> print(list(range(1, 100)))    # doctest: +ELLIPSIS
+        [1, 2, ..., 98, 99]
+        """
+        return x
+
+    sections, errors = parse(
+        inspect.getdoc(f),
+        inspect.signature(f),
+        trim_doctest=True,
+    )
+    assert len(sections) == 2
+    assert len(sections[1].value) == 4
+    assert not errors
+
+    # Verify that doctest flags have indeed been trimmed
+    example_str = sections[1].value[1][1]
+    assert "# doctest: +SKIP" not in example_str
+    example_str = sections[1].value[3][1]
+    assert "<BLANKLINE>" not in example_str
+    assert "\n>>> print(list(range(1, 100)))\n" in example_str
+
+
 def test_function_with_examples():
-    """Parse a function docstring with signature annotations."""
+    """Parse a function docstring with examples."""
 
     def f(x: int, y: int) -> int:
         """


### PR DESCRIPTION
Related to: https://github.com/mkdocstrings/mkdocstrings/issues/386

I've decided to start the work on the above issue starting from the legacy parser. Please take a look and see if I'm going in the right direction or if I've missed anything crucial.

## Key PR pointers

* Feat: Implemented the functionality of removal of `# doctest:` and `<BLANKLINE>` via regex; in *both* cases where 1. line starts with `>>>` and 2. line is "in a code example block". This is activated via the new `trim_doctest_flags` parameter / option.
* As mentioned in the parent issue, I have set the default behaviour of `trim_doctest_flags` to be True. To keep consistent with Sphinx.
* Only implemented for Google and Numpy for now. I'm not sure how to do it for Rst, it doesn't seem like Rst is parsing examples explicitly (or at all?). If there is a way to implement for Rst, I would be grateful if you could nudge me in the right direction. I'll try to incorporate it into this PR as well. (since our `pyjanitor` project is using the rst / legacy-python combination 😅 ）
* Tests: Added one test function specifically for testing the removal of doctest flags. I've set `trim_doctest_flags=False` as default argument in the test suite.
* Docs: I've updated README (and took the liberty to reorganize the prose a little) to point out this new trim doctest option is available under `docstring_options`.

## Addendum

* The regular expression used by CPython doctest module to catch doctest flags / directives can be found here: https://github.com/python/cpython/blob/3.10/Lib/doctest.py#L744
* Similarly for the BLANKLINE: https://github.com/python/cpython/blob/3.10/Lib/doctest.py#L1628
