### PR TITLE
fix: warn about missing descriptions and return "" not `None`

### DIFF
--- a/src/pytkdocs/parsers/docstrings/numpy.py
+++ b/src/pytkdocs/parsers/docstrings/numpy.py
@@ -90,7 +90,7 @@ class Numpy(Parser):
                     default = signature_param.default
                 kind = signature_param.kind
             
-            description = param.description if param.description else ""
+            description = param.description or ""
             if not description:
                 self.error(f"No description for parameter '{name}'")
             
@@ -129,7 +129,7 @@ class Numpy(Parser):
         docstring_attributes = [p for p in docstring_obj.params if p.args[0] == "attribute"]
 
         for attr in docstring_attributes:
-            description = attr.description if attr.description else ""
+            description = attr.description or ""
             if not description:
                 self.error(f"No description for attribute '{attr.arg_name}'")
             attributes.append(
@@ -165,7 +165,7 @@ class Numpy(Parser):
         except_obj = docstring_obj.raises
 
         for exception in except_obj:
-            description = exception.description if exception.description else ""
+            description = exception.description or ""
             if not description:
                 self.error(f"No description for exception '{exception.type_name}'")
             exceptions.append(AnnotatedObject(exception.type_name, exception.description))

--- a/src/pytkdocs/parsers/docstrings/numpy.py
+++ b/src/pytkdocs/parsers/docstrings/numpy.py
@@ -168,7 +168,7 @@ class Numpy(Parser):
             description = exception.description or ""
             if not description:
                 self.error(f"No description for exception '{exception.type_name}'")
-            exceptions.append(AnnotatedObject(exception.type_name, exception.description))
+            exceptions.append(AnnotatedObject(exception.type_name, description))
 
         if exceptions:
             return Section(Section.Type.EXCEPTIONS, exceptions)

--- a/src/pytkdocs/parsers/docstrings/numpy.py
+++ b/src/pytkdocs/parsers/docstrings/numpy.py
@@ -89,11 +89,16 @@ class Numpy(Parser):
                 if signature_param.default is not empty:
                     default = signature_param.default
                 kind = signature_param.kind
+            
+            description = param.description if param.description else ""
+            if not description:
+                self.error(f"No description for parameter '{name}'")
+            
             parameters.append(
                 Parameter(
                     name=param.arg_name,
                     annotation=type_name,
-                    description=param.description,
+                    description=description,
                     default=default,
                     kind=kind,
                 )
@@ -124,6 +129,9 @@ class Numpy(Parser):
         docstring_attributes = [p for p in docstring_obj.params if p.args[0] == "attribute"]
 
         for attr in docstring_attributes:
+            description = attr.description if attr.description else ""
+            if not description:
+                self.error(f"No description for attribute '{attr.arg_name}'")
             attributes.append(
                 Attribute(
                     name=attr.arg_name,
@@ -157,6 +165,9 @@ class Numpy(Parser):
         except_obj = docstring_obj.raises
 
         for exception in except_obj:
+            description = exception.description if exception.description else ""
+            if not description:
+                self.error(f"No description for exception '{exception.type_name}'")
             exceptions.append(AnnotatedObject(exception.type_name, exception.description))
 
         if exceptions:
@@ -178,26 +189,31 @@ class Numpy(Parser):
         Returns:
             A `Section` object (or `None` if section is empty).
         """
-        return_obj = docstring_obj.returns if docstring_obj.returns else []
-        text = return_obj.description if return_obj else ""
+        if docstring_obj.returns:
+            return_obj =  docstring_obj.returns
+            
+            if return_obj.description:
+                description = return_obj.description
+            else: 
+                self.error("Empty return description")
+                description = ""
 
-        if self.context["signature"]:
-            annotation = self.context["signature"].return_annotation
-        else:
-            annotation = self.context["annotation"]
-
-        if annotation is empty:
-            if text:
-                annotation = return_obj.type_name or empty
-                text = return_obj.description
-            elif return_obj and annotation is empty:
+            if self.context["signature"]:
+                annotation = self.context["signature"].return_annotation
+            else:
+                annotation = self.context["annotation"]
+            
+            if annotation is empty and return_obj.type_name:
+                annotation = return_obj.type_name
+            
+            if not annotation:
                 self.error("No return type annotation")
+                annotation = ""
 
-        if return_obj and not text:
-            self.error("Empty return description")
-        if not return_obj or annotation is empty or not text:
-            return None
-        return Section(Section.Type.RETURN, AnnotatedObject(annotation, text))
+            if annotation or description:
+                return Section(Section.Type.RETURN, AnnotatedObject(annotation, description))
+        
+        return None
 
     def read_examples_section(
         self,

--- a/tests/test_parsers/test_docstrings/test_numpy.py
+++ b/tests/test_parsers/test_docstrings/test_numpy.py
@@ -92,8 +92,6 @@ def test_sections_without_description():
         ----------
         void : str
         niet : str
-        nada : str
-        rien : str
 
         Raises
         ------
@@ -104,12 +102,19 @@ def test_sections_without_description():
         bool
         """
     )
+    
+    # Assert that errors are as expected
     assert len(sections) == 4
-    assert len(errors) == 10
-    for error in errors[:8]:
+    assert len(errors) == 6
+    for error in errors[:4]:
         assert "param" in error
-    assert "exception" in errors[8]
-    assert "return description" in errors[9]
+    assert "exception" in errors[4]
+    assert "return description" in errors[5]
+    
+    # Assert that no descriptions are ever None (can cause exceptions downstream)
+    for s in sections:
+        for v in s.value:
+            assert v.description is not None
 
 
 def test_property_docstring():

--- a/tests/test_parsers/test_docstrings/test_numpy.py
+++ b/tests/test_parsers/test_docstrings/test_numpy.py
@@ -4,6 +4,7 @@ import inspect
 from textwrap import dedent
 
 from pytkdocs.loader import Loader
+from pytkdocs.parsers.docstrings.base import Section
 from pytkdocs.parsers.docstrings.numpy import Numpy
 
 
@@ -112,10 +113,16 @@ def test_sections_without_description():
     assert "return description" in errors[5]
     
     # Assert that no descriptions are ever None (can cause exceptions downstream)
-    for s in sections:
-        for v in s.value:
-            assert v.description is not None
-
+    assert sections[1].type is Section.Type.PARAMETERS
+    for p in sections[1].value:
+        assert p.description is not None
+    
+    assert sections[2].type is Section.Type.EXCEPTIONS
+    for p in sections[2].value:
+        assert p.description is not None
+    
+    assert sections[3].type is Section.Type.RETURN
+    assert sections[3].value.description is not None
 
 def test_property_docstring():
     """Parse a property docstring."""

--- a/tests/test_parsers/test_docstrings/test_numpy.py
+++ b/tests/test_parsers/test_docstrings/test_numpy.py
@@ -81,6 +81,37 @@ def test_sections_without_signature():
         assert "param" in error
 
 
+def test_sections_without_description():
+    """Parse a docstring without descriptions."""
+    # type of return value always required
+    sections, errors = parse(
+        """
+        Sections without descriptions.
+
+        Parameters
+        ----------
+        void : str
+        niet : str
+        nada : str
+        rien : str
+
+        Raises
+        ------
+        GlobalError
+
+        Returns
+        -------
+        bool
+        """
+    )
+    assert len(sections) == 4
+    assert len(errors) == 10
+    for error in errors[:8]:
+        assert "param" in error
+    assert "exception" in errors[8]
+    assert "return description" in errors[9]
+
+
 def test_property_docstring():
     """Parse a property docstring."""
     class_ = Loader().get_object_documentation("tests.fixtures.parsing.docstrings.NotDefinedYet")


### PR DESCRIPTION
This should fix https://github.com/mkdocstrings/mkdocstrings/pull/397 and #137 .

The problem was that empty descriptions were being returned as None in `Parameters` and `Exceptions` blocks instead of `""`. 

That None eventually made it to this: <https://github.com/mkdocstrings/mkdocstrings/blob/master/src/mkdocstrings/handlers/base.py#L219>

And that passed it here: <https://github.com/Python-Markdown/markdown/blob/master/markdown/core.py#L225>

And later in that function we get a Nonetype error: <https://github.com/Python-Markdown/markdown/blob/master/markdown/core.py#L248>

Because we also were not recording empty descriptions as errors (which I believe mkdocstrings interprets and reports as warnings) there was nothing to tell the user _why_  `python -m mkdocs build` had thrown a Nonetype error.

So I:
- Recorded missing descriptions as errors.
- Changed the code to return all missing descriptions as `""` instead of `None`.
- Added test to verify capability.